### PR TITLE
fix error with brackets

### DIFF
--- a/src/helpers/blockchain-helper.js
+++ b/src/helpers/blockchain-helper.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
 				web3 = new Web3(web3.currentProvider)
 			}
 			else {
-				web3 = new Web3(new Web3.providers.HttpProvider(config.Ethereum[config.environment].rpc))
+				web3 = new Web3(new Web3.providers.HttpProvider(config.Ethereum[config.environment]).rpc)
 			}
 
 			if (typeof web3 !== 'undefined') {


### PR DESCRIPTION
Fixes 

```
TypeError: Cannot read property 'rpc' of undefined
    at /home/rinke/Projects/goerli-faucet/src/helpers/blockchain-helper.js:13:89
```

upon running `npm start`